### PR TITLE
Pin glob version to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "aliyun-sdk": "*",
     "async": "*",
-    "glob": "*",
+    "glob": "^8.1.0",
     "mime-types": "*",
     "shelljs": "*",
     "yargs": "*"


### PR DESCRIPTION
glob.sync is removed in glob 9, the commit pin the version to fix the issue for now.  
```
uploading webpack...
/usr/local/lib/node_modules/aliyun-cli-2/bin/oss-cli.js:99
        let lstfile = glob.sync(basearr[j] + '/**/.');
                           ^

TypeError: glob.sync is not a function
    at Object.<anonymous> (/usr/local/lib/node_modules/aliyun-cli-2/bin/oss-cli.js:99:28)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
```